### PR TITLE
fix: package comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-%:
 	cd $(subst :,/,$*); go test ./... -coverprofile cover.out ;
 
 lint:
-	revive -config revive.toml ./..
+	revive -config revive.toml ./...
 
 scan:
 	$(MAKE) $(addprefix scan-, $(MODULES))

--- a/helpers/files.go
+++ b/helpers/files.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/hash.go
+++ b/helpers/hash.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/io.go
+++ b/helpers/io.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 const (

--- a/helpers/misc.go
+++ b/helpers/misc.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/misc_test.go
+++ b/helpers/misc_test.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/progress.go
+++ b/helpers/progress.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import "io"

--- a/helpers/random.go
+++ b/helpers/random.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/slice.go
+++ b/helpers/slice.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import "strings"

--- a/helpers/text.go
+++ b/helpers/text.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/transport.go
+++ b/helpers/transport.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic utility functions.
 package helpers
 
 import (

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// Package helpers provides generic helper functions
 package helpers
 
 import (

--- a/internal/release/main_test.go
+++ b/internal/release/main_test.go
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2024-Present Defense Unicorns
 
-// package main outputs the next semver version for the given package using git history and conventional commits
 package main
 
 import (


### PR DESCRIPTION
## Description

Fix package comments to look prettier on `pkg.go.dev`.

