### PR TITLE
ci: define least privilege permissions for commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,5 +1,8 @@
 name: PR Title Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Description
Define least privilege permissions for commitlint workflow

## Related Issue

Fixes #46 
