### PR TITLE
chore: fix helpers/v2 module declaration

### DIFF
--- a/helpers/go.mod
+++ b/helpers/go.mod
@@ -1,4 +1,4 @@
-module github.com/defenseunicorns/pkg/helpers
+module github.com/defenseunicorns/pkg/helpers/v2
 
 go 1.21.8
 


### PR DESCRIPTION
## Description

This fixes helpers on imports by adding `/v2` to the `module`.

## Related Issue

Fixes #N/A
