### PR TITLE
fix(oci): fix auth client creation

### DIFF
--- a/oci/common.go
+++ b/oci/common.go
@@ -81,7 +81,13 @@ func NewOrasRemote(url string, platform ocispec.Platform, mods ...Modifier) (*Or
 		return nil, fmt.Errorf("failed to parse OCI reference %q: %w", url, err)
 	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	client := auth.DefaultClient
+	client := &auth.Client{
+		Client: retry.DefaultClient,
+		Header: http.Header{
+			"User-Agent": {"oras-go"},
+		},
+		Cache: auth.DefaultCache,
+	}
 	client.Client.Transport = transport
 	o := &OrasRemote{
 		repo:           &remote.Repository{Client: client},


### PR DESCRIPTION
## Description

The use of the DefaultClient is resulting in a shared reference between multiple remotes. In the case of publishing - the CredentialStore is always modified by the last remote created - which can result in authentication for whichever remote was created first being invalid. 

## Related Issue

Relates to https://github.com/zarf-dev/zarf/issues/3647

## Screenshots

### Before
![Screenshot 2025-04-09 at 11 08 58 AM](https://github.com/user-attachments/assets/c229e035-5aca-4f51-9d31-a93a77c692f4)

### After
![Screenshot 2025-04-09 at 11 08 12 AM](https://github.com/user-attachments/assets/7de83263-4158-4b34-8002-8355c86138ed)

