### PR TITLE
fix: allow `o.PullPath` to pull paths with sub directories

### DIFF
--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -143,7 +143,9 @@ func (suite *OCISuite) TestCopyToTarget() {
 func (suite *OCISuite) TestPulledPaths() {
 	ctx := context.TODO()
 	srcTempDir := suite.T().TempDir()
-	files := []string{"firstFile", "secondFile"}
+	err := helpers.CreateDirectory(filepath.Join(srcTempDir, "subdir"), helpers.ReadExecuteAllWriteUser)
+	suite.NoError(err)
+	files := []string{"firstFile", filepath.Join("subdir", "secondFile")}
 
 	var descs []ocispec.Descriptor
 	src, err := file.New(srcTempDir)

--- a/oci/pull.go
+++ b/oci/pull.go
@@ -96,7 +96,13 @@ func (o *OrasRemote) PullPath(ctx context.Context, destinationDir string, desc o
 		return errors.New("failed to pull layer: layer is not a file")
 	}
 
-	return os.WriteFile(filepath.Join(destinationDir, rel), b, helpers.ReadWriteUser)
+	fullPath := filepath.Join(destinationDir, rel)
+	dirPath := filepath.Dir(fullPath)
+	if err := helpers.CreateDirectory(dirPath, helpers.ReadExecuteAllWriteUser); err != nil {
+		return err
+	}
+
+	return os.WriteFile(fullPath, b, helpers.ReadWriteUser)
 }
 
 // PullPaths pulls multiple files from the remote repository and saves them to `destinationDir`.


### PR DESCRIPTION
## Description

There is currently an issue in `o.pullPath` that forces users to create the entire path ahead of time before pulling an image. This can be problematic for layers that define a multi directory path such as `components/baseline.tar`. The caller would have to know to create the `components` directory ahead of time. 
