### PR TITLE
feat: add fetch layer reader

### DIFF
--- a/oci/fetch.go
+++ b/oci/fetch.go
@@ -76,6 +76,20 @@ func (o *OrasRemote) FetchLayer(ctx context.Context, desc ocispec.Descriptor) (b
 	return content.FetchAll(ctx, src, desc)
 }
 
+// FetchLayerReader fetches the layer with the given descriptor from the remote repository.
+func (o *OrasRemote) FetchLayerReader(ctx context.Context, desc ocispec.Descriptor) (*content.VerifyReader, error) {
+	var src oras.ReadOnlyTarget
+	src = o.repo
+	if o.cache != nil {
+		src = orasCache.New(o.repo, o.cache)
+	}
+	r, err := src.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	return content.NewVerifyReader(r, desc), nil
+}
+
 // FetchJSONFile fetches the given JSON file from the remote repository.
 func FetchJSONFile[T any](ctx context.Context, fetcher func(ctx context.Context, desc ocispec.Descriptor) (bytes []byte, err error), manifest *Manifest, path string) (result T, err error) {
 	descriptor := manifest.Locate(path)

--- a/oci/pull.go
+++ b/oci/pull.go
@@ -104,7 +104,7 @@ func (o *OrasRemote) PullPath(ctx context.Context, destinationDir string, desc o
 		return err
 	}
 
-	file, err := os.Create(fullPath)
+	file, err := os.OpenFile(fullPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, helpers.ReadWriteUser)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
This adds a new function `o.FetchLayerReader`, and uses it in `o.PullPath`. This makes the function more efficient by writing directly to the file system rather than writing to an in memory byte array first