### PR TITLE
fix: avoid `mergeMapRecursive` panic on empty map

### DIFF
--- a/helpers/misc.go
+++ b/helpers/misc.go
@@ -95,6 +95,10 @@ func TransformAndMergeMap[T any](m1, m2 map[string]T, transform func(string) str
 func MergeMapRecursive(m1, m2 map[string]any) (r map[string]any) {
 	r = maps.Clone(m1)
 
+	if r == nil {
+		r = map[string]any{}
+	}
+
 	for key, value := range m2 {
 		if value, ok := value.(map[string]any); ok {
 			if nestedValue, ok := r[key]; ok {

--- a/helpers/misc_test.go
+++ b/helpers/misc_test.go
@@ -178,19 +178,26 @@ func (suite *TestMiscSuite) TestTransformAndMergeMap() {
 }
 
 func (suite *TestMiscSuite) TestMergeMapRecursive() {
-	expected := map[string]any{
-		"different": "value",
-		"hello":     "it's me",
-		"unique":    "value",
-		"nested": map[string]any{
-			"values":    "doggo",
+	suite.Run("MergeMapRecursive", func() {
+		expected := map[string]any{
 			"different": "value",
+			"hello":     "it's me",
 			"unique":    "value",
-		},
-	}
+			"nested": map[string]any{
+				"values":    "doggo",
+				"different": "value",
+				"unique":    "value",
+			},
+		}
 
-	result := MergeMapRecursive(suite.map1, suite.map2)
-	suite.Equal(expected, result)
+		result := MergeMapRecursive(suite.map1, suite.map2)
+		suite.Equal(expected, result)
+	})
+
+	suite.Run("MergeMapRecursiveNil", func() {
+		result := MergeMapRecursive(nil, suite.map2)
+		suite.Equal(suite.map2, result)
+	})
 }
 
 func (suite *TestMiscSuite) TestIsNotZeroAndNotEqual() {


### PR DESCRIPTION
## Description

Fixes a bug where `mergeMapRecursive` would panic if m1 was set to nil and m2 was not set to nil
